### PR TITLE
Conditional deploy from master branch only.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
           
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/master'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./dist


### PR DESCRIPTION
Thereby preventing overwriting master deployment target with pull_request content. When we have a proper deployment target for reviewing pull requests we can create either a dedicated gh action or extend main with another conditional step.